### PR TITLE
Depend on our version of the java installer

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 # file: cassandra/meta/main.yml
 dependencies:
-  - role: smola.java
+  - role: dwcramer.java
     java_packages: [ "oracle-java7-installer" ]
   - role: tersmitten.ntp
 


### PR DESCRIPTION
I cut a release of the java installer so we can depend on a specific version in our ansible-requirements.yml file. Updating your dependency to use our version.
